### PR TITLE
Fix #5 | allow something like "10-8" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+### 0.9.12
+- Fixed a bug where subtracting more coins than there were available would leave an empty field.
+- Added the possibility to write something like 100-90 instead of -90 (no complex math).
 ### 0.9.11
 - Fixed a bug where the module would remove currency from higher denominations even when there was enough to pay.
 ### 0.9.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## Changelog
+### 0.9.11
+- Fixed a bug where the module would remove currency from higher denominations even when there was enough to pay.
+### 0.9.10
+- Reworked the logic for removing currency so it doesn't always start with the highest denomination.
+### 0.9.9
+- Added an option to ignore electrum when converting.
+### 0.9.8
+- Lazy Money now uses the currency conversion rates from `CONFIG.DND5E.currencyConversion`.
+### 0.9.7
+- Added an option to automatically convert when adding currency.
+- Added a brief red flash to indicate if there isn't enough currency to remove.

--- a/README.md
+++ b/README.md
@@ -9,18 +9,8 @@ Easily add or remove currency with automatic conversion and no overdraft.
 4. Paste `https://github.com/DeVelox/lazymoney/raw/master/module.json` into the "Manifest URL" field
 5. Click "Install"
 ## Notes
-- When removing currency it will remove from the highest available denomination first.
-- When adding currency it will simply add it without implicit conversion (by default).
-- Won't allow removing more currency than is available in total.
+- When removing currency the module will remove it from higher denominations when necessary.
+- When adding currency the module will simply add it without implicit conversion (by default).
+- The module won't allow removing more currency than is available in total.
 ## Compatibility
 Currently supports any dnd5e character sheet that doesn't change the name of currency input fields.
-## Changelog
-### 0.9.10
-- Reworked the logic for removing money so it doesn't always start with the highest denomination.
-### 0.9.9
-- Added an option to ignore electrum when converting.
-### 0.9.8
-- Lazy Money now uses the currency conversion rates from `CONFIG.DND5E.currencyConversion`.
-### 0.9.7
-- Added an option to automatically convert when adding currency.
-- Added a brief red flash to indicate if there isn't enough currency to remove.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "title": "Lazy Money",
   "description": "Easily add or remove currency with automatic conversion and no overdraft.",
   "author": "DeVelox",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "0.8.7",
   "systems": [

--- a/module.json
+++ b/module.json
@@ -3,10 +3,12 @@
   "title": "Lazy Money",
   "description": "Easily add or remove currency with automatic conversion and no overdraft.",
   "author": "DeVelox",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "minimumCoreVersion": "0.6.0",
-  "compatibleCoreVersion": "0.7.5",
-  "system": "dnd5e",
+  "compatibleCoreVersion": "0.8.7",
+  "systems": [
+    "dnd5e"
+  ],
   "url": "https://github.com/DeVelox/lazymoney",
   "manifest": "https://github.com/DeVelox/lazymoney/raw/master/module.json",
   "download": "https://github.com/DeVelox/lazymoney/archive/master.zip",

--- a/scripts/lazymoney.js
+++ b/scripts/lazymoney.js
@@ -165,17 +165,19 @@ function addMoney(oldAmount, delta, denom) {
 function removeMoney(oldAmount, delta, denom) {
   const cpValue = getCpValue();
   let newAmount = oldAmount;
-  let newDelta;
-  let down;
   if (oldAmount[denom] >= delta) {
     newAmount[denom] = oldAmount[denom] - delta;
     return newAmount;
   }
-  else {
-    newDelta = getDelta(delta, denom);
-    delta = delta * cpValue[denom].value;
-  }
-  if (totalMoney(oldAmount) >= delta * cpValue[denom]) {
+
+  if (totalMoney(oldAmount) >= delta * cpValue[denom].value) {
+    let overflow = delta - oldAmount[denom];
+    oldAmount[denom] -= (delta-overflow);
+    let newDelta = getDelta(overflow, denom);
+    newDelta = newDelta === 0 ? 1 : newDelta;
+    let newAmount = oldAmount;
+    let down;
+
     for (let [key, value] of Object.entries(newDelta)) {
       if (newAmount[key] >= value) {
         newAmount[key] -= value;
@@ -198,7 +200,7 @@ function removeMoney(oldAmount, delta, denom) {
     return newAmount;
   }
   else {
-    return oldAmount;
+    return newAmount;
   }
 }
 

--- a/scripts/lazymoney.js
+++ b/scripts/lazymoney.js
@@ -78,7 +78,7 @@ function _onChangeCurrency(ev) {
         break;
       default:
         newAmount = updateMoney(money, delta, denom);
-        break ;
+        break;
     }
   }
   if (Object.keys(newAmount).length > 0) {
@@ -163,26 +163,22 @@ function addMoney(oldAmount, delta, denom) {
 }
 
 function removeMoney(oldAmount, delta, denom) {
-
-  if (oldAmount[denom] >= delta) {
-    oldAmount[denom] -= delta;
-    return oldAmount;
-  }
   const cpValue = getCpValue();
-
+  let newAmount = oldAmount;
+  let newDelta;
+  let down;
+  if (oldAmount[denom] >= delta) {
+    newAmount[denom] = oldAmount[denom] - delta;
+    return newAmount;
+  }
+  else {
+    newDelta = getDelta(delta, denom);
+    delta = delta * cpValue[denom].value;
+  }
   if (totalMoney(oldAmount) >= delta * cpValue[denom]) {
-
-
-    let overflow = delta - oldAmount[denom];
-    oldAmount[denom] -= (delta-overflow);
-    let newDelta = getDelta(overflow, denom);
-    newDelta = newDelta === 0 ? 1 : newDelta;
-    let newAmount = oldAmount;
-    let down;
-
     for (let [key, value] of Object.entries(newDelta)) {
       if (newAmount[key] >= value) {
-          newAmount[key] -= value;
+        newAmount[key] -= value;
       }
       else if (newAmount === scaleDown(newAmount, key)) {
         newAmount[key] -= value;


### PR DESCRIPTION
Version 9.11 had issues when doing something like 80-81, this did not work correctly.

Also added simple logic to allow something like "10-8" instead of "-8" as I often double click and suddenly the input field is blank,